### PR TITLE
Fix null value exception when loading departments

### DIFF
--- a/CamcoTasks.Infrastructure/Entities/HR/DepartmentAndManager.cs
+++ b/CamcoTasks.Infrastructure/Entities/HR/DepartmentAndManager.cs
@@ -22,12 +22,12 @@ public class DepartmentAndManager
     [Column("DepartmentAbbreviation", TypeName = "varchar(2)")]
     [StringLength(2)]
     [MaxLength(2)]
-    public string DepartmentAbbreviation { get; set; }
+    public string? DepartmentAbbreviation { get; set; }
 
     [Column("DepartmentImage", TypeName = "nvarchar(255)")]
     [StringLength(255)]
     [MaxLength(255)]
-    public string DepartmentImage { get; set; }
+    public string? DepartmentImage { get; set; }
 
     [Browsable(false)]
     [Column("PrimaryManagerId", TypeName = "bigint")]


### PR DESCRIPTION
## Summary
- mark DepartmentAbbreviation and DepartmentImage as nullable strings

## Testing
- `dotnet build CamcoTasks.sln --no-restore -c Release` *(fails: command not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688c8db0ea28832d8173b59273ad318b