### PR TITLE
Update TaskChart to use StatusType

### DIFF
--- a/CamcoTasks/Pages/Chart.razor
+++ b/CamcoTasks/Pages/Chart.razor
@@ -1,4 +1,8 @@
 ﻿@page "/TaskChart"
+@using CamcoTasks.Infrastructure.EnumHelper.Enums.Task
+@using System.ComponentModel.DataAnnotations
+@using CamcoTasks.Service.IService
+@inject ITasksService TasksService
 @inject IJSRuntime JS
 
 <div class="inline-flex items-center gap-4 p-4 w-full h-full rounded-[16px] flex-col overflow-visible"
@@ -9,7 +13,7 @@
                 <!-- Icon placeholder -->
             </div>
             <div class="text-[#171412] text-base font-medium leading-6 font-['Roboto']">
-                Budget Expense
+                Task Statuses
             </div>
             <img class="img" src="img/budget-menu-icon.svg" />
         </div>
@@ -27,24 +31,18 @@
 </div>
 
 @code {
-    public class BudgetItemDto
+    public class StatusItemDto
     {
-        public string? CategoryName { get; set; }
-        public decimal ActualAmount { get; set; }
+        public StatusType Status { get; set; }
+        public string StatusName { get; set; } = string.Empty;
+        public int Count { get; set; }
     }
 
-    private List<BudgetItemDto> BudgetItems { get; set; } = new()
-    {
-        new BudgetItemDto { CategoryName = "Invitations & Stationary", ActualAmount = 500 },
-        new BudgetItemDto { CategoryName = "Decor & Design", ActualAmount = 300 },
-        new BudgetItemDto { CategoryName = "Food & Beverage", ActualAmount = 400 }
-    };
-
+    private List<StatusItemDto> StatusItems { get; set; } = new();
     private List<object> ChartData { get; set; } = new();
     private bool chartReady = false;
     private bool isClientReady = false;
-    private decimal TotalSpent { get; set; } = 0;
-    private int nextTaskId = 1;
+    private int TotalInProgress { get; set; } = 0;
     private bool _hasInitialized;
 
     protected override async Task OnInitializedAsync()
@@ -66,23 +64,25 @@
 
     private async Task LoadChartDataAsync()
     {
-        BudgetItems = BudgetItems
-            .Where(item => !string.IsNullOrEmpty(item.CategoryName))
-            .GroupBy(item => item.CategoryName!)
-            .Select(group => new BudgetItemDto
+        var tasks = (await TasksService.GetAllTasks()).ToList();
+
+        StatusItems = tasks
+            .GroupBy(t => t.TaskStatusId.HasValue ? (StatusType)t.TaskStatusId.Value : StatusType.Default)
+            .Select(g => new StatusItemDto
             {
-                CategoryName = group.Key,
-                ActualAmount = group.Sum(i => i.ActualAmount)
+                Status = g.Key,
+                StatusName = GetEnumDisplayName(g.Key),
+                Count = g.Count()
             })
             .ToList();
 
-        TotalSpent = BudgetItems.Sum(b => b.ActualAmount);
+        TotalInProgress = StatusItems.FirstOrDefault(s => s.Status == StatusType.InProgress)?.Count ?? 0;
 
-        ChartData = BudgetItems.Select(item => new Dictionary<string, object>
+        ChartData = StatusItems.Select(item => new Dictionary<string, object>
         {
-            { "categoryName", item.CategoryName ?? string.Empty },
-            { "actualAmount", item.ActualAmount },
-            { "color", GetColorForCategory(item.CategoryName) }
+            { "categoryName", item.StatusName },
+            { "actualAmount", item.Count },
+            { "color", GetColorForStatus(item.Status) }
         }).ToList<object>();
 
         chartReady = true;
@@ -94,7 +94,7 @@
         {
             if (chartReady && isClientReady)
                 await Task.Delay(1000);
-            await JS.InvokeVoidAsync("renderSpentChart", ChartData, TotalSpent);
+            await JS.InvokeVoidAsync("renderSpentChart", ChartData, TotalInProgress);
         }
         catch (JSException ex)
         {
@@ -104,10 +104,11 @@
 
     private async Task AddNewTask()
     {
-        BudgetItems.Add(new BudgetItemDto
+        StatusItems.Add(new StatusItemDto
         {
-            CategoryName = $"Task {nextTaskId++}",
-            ActualAmount = 0
+            Status = StatusType.InProgress,
+            StatusName = GetEnumDisplayName(StatusType.InProgress),
+            Count = 1
         });
 
         await RefreshChartAsync();
@@ -119,11 +120,24 @@
         await RenderChartAsync();
     }
 
-    private string GetColorForCategory(string? name) => name switch
+    private string GetColorForStatus(StatusType status) => status switch
     {
-        "Invitations & Stationary" => "#81B29A",
-        "Decor & Design" => "#E07A5F",
-        "Food & Beverage" => "#F2CC8F",
+        StatusType.InProgress => "#81B29A",
+        StatusType.Pending => "#E07A5F",
+        StatusType.WaitingForReview => "#F2CC8F",
+        StatusType.Tabled => "#6D597A",
+        StatusType.TemporaryTabled => "#B56576",
+        StatusType.Done => "#355070",
         _ => "#CCCCCC"
     };
+
+    private static string GetEnumDisplayName(StatusType status)
+    {
+        var displayAttribute = status.GetType()
+            .GetField(status.ToString())?
+            .GetCustomAttributes(typeof(DisplayAttribute), false)
+            .FirstOrDefault() as DisplayAttribute;
+
+        return displayAttribute?.Name ?? status.ToString();
+    }
 }

--- a/CamcoTasks/wwwroot/js/Chart.js
+++ b/CamcoTasks/wwwroot/js/Chart.js
@@ -27,8 +27,8 @@
 
     function getCenterText(amount) {
         return [
-            '{spent|SPENT}',
-            `$${amount.toLocaleString(undefined, {
+            '{spent|TASKS IN PROGRESS}',
+            `${amount.toLocaleString(undefined, {
                 minimumFractionDigits: 0,
                 maximumFractionDigits: 0
             })}`
@@ -56,7 +56,7 @@
                         ${params.name}
                     </div>
                     <div style="text-align:left;font-size:12px;line-height:16px;">
-                        $${params.value}
+                        ${params.value}
                     </div>`;
             }
         },
@@ -159,15 +159,7 @@
     const debouncedResize = debounce(() => myChart.resize(), 200);
     window.addEventListener('resize', debouncedResize);
 
-    myChart.on('legendselectchanged', function (event) {
-        let selected = event.selected;
-        let newTotal = 0;
-        data.forEach(item => {
-            if (selected[item.name] !== false) {
-                newTotal += item.value;
-            }
-        });
-
+    myChart.on('legendselectchanged', function () {
         myChart.setOption({
             graphic: {
                 elements: [
@@ -176,7 +168,7 @@
                         left: textPos.left,
                         top: textPos.top,
                         style: {
-                            text: getCenterText(newTotal),
+                            text: getCenterText(totalSpent),
                             textAlign: 'center',
                             textVerticalAlign: 'middle',
                             fontSize: 24,


### PR DESCRIPTION
## Summary
- use task status data instead of placeholder budget items
- display in-progress task count in the centre of the chart
- adjust Chart.js to show plain numbers and constant centre text

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbd4d7770832db1f26f93b6756802