### PR TITLE
Update TaskChart to display status counts correctly

### DIFF
--- a/CamcoTasks/Pages/Chart.razor
+++ b/CamcoTasks/Pages/Chart.razor
@@ -1,4 +1,8 @@
 ﻿@page "/TaskChart"
+@using CamcoTasks.Infrastructure.EnumHelper.Enums.Task
+@using System.ComponentModel.DataAnnotations
+@using CamcoTasks.Service.IService
+@inject ITasksService TasksService
 @inject IJSRuntime JS
 
 <div class="inline-flex items-center gap-4 p-4 w-full h-full rounded-[16px] flex-col overflow-visible"
@@ -9,7 +13,7 @@
                 <!-- Icon placeholder -->
             </div>
             <div class="text-[#171412] text-base font-medium leading-6 font-['Roboto']">
-                Budget Expense
+                Task Statuses
             </div>
             <img class="img" src="img/budget-menu-icon.svg" />
         </div>
@@ -18,7 +22,7 @@
 
     <div class="flex-1 h-px outline outline-1 outline-[#ECEBE9] outline-offset-[-0.5px] w-full my-3"></div>
 
-    <div id="spentChart" style="width:100%;min-height:300px;">
+    <div id="spentChart" style="width:100%;min-height:500px;">
         @if (!chartReady)
         {
             <div class="text-center py-10 text-gray-500">Loading chart...</div>
@@ -27,24 +31,18 @@
 </div>
 
 @code {
-    public class BudgetItemDto
+    public class StatusItemDto
     {
-        public string? CategoryName { get; set; }
-        public decimal ActualAmount { get; set; }
+        public StatusType Status { get; set; }
+        public string StatusName { get; set; } = string.Empty;
+        public int Count { get; set; }
     }
 
-    private List<BudgetItemDto> BudgetItems { get; set; } = new()
-    {
-        new BudgetItemDto { CategoryName = "Invitations & Stationary", ActualAmount = 500 },
-        new BudgetItemDto { CategoryName = "Decor & Design", ActualAmount = 300 },
-        new BudgetItemDto { CategoryName = "Food & Beverage", ActualAmount = 400 }
-    };
-
+    private List<StatusItemDto> StatusItems { get; set; } = new();
     private List<object> ChartData { get; set; } = new();
     private bool chartReady = false;
     private bool isClientReady = false;
-    private decimal TotalSpent { get; set; } = 0;
-    private int nextTaskId = 1;
+    private int TotalInProgress { get; set; } = 0;
     private bool _hasInitialized;
 
     protected override async Task OnInitializedAsync()
@@ -66,23 +64,32 @@
 
     private async Task LoadChartDataAsync()
     {
-        BudgetItems = BudgetItems
-            .Where(item => !string.IsNullOrEmpty(item.CategoryName))
-            .GroupBy(item => item.CategoryName!)
-            .Select(group => new BudgetItemDto
+        var tasks = (await TasksService.GetAllTasks()).ToList();
+
+        var grouped = tasks
+            .GroupBy(t => t.TaskStatusId ?? (int)StatusType.Default)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        StatusItems = Enum.GetValues<StatusType>()
+            .Select(status =>
             {
-                CategoryName = group.Key,
-                ActualAmount = group.Sum(i => i.ActualAmount)
+                grouped.TryGetValue((int)status, out int count);
+                return new StatusItemDto
+                {
+                    Status = status,
+                    StatusName = GetEnumDisplayName(status),
+                    Count = count
+                };
             })
             .ToList();
 
-        TotalSpent = BudgetItems.Sum(b => b.ActualAmount);
+        TotalInProgress = StatusItems.First(s => s.Status == StatusType.InProgress).Count;
 
-        ChartData = BudgetItems.Select(item => new Dictionary<string, object>
+        ChartData = StatusItems.Select(item => new Dictionary<string, object>
         {
-            { "categoryName", item.CategoryName ?? string.Empty },
-            { "actualAmount", item.ActualAmount },
-            { "color", GetColorForCategory(item.CategoryName) }
+            { "categoryName", item.StatusName },
+            { "actualAmount", item.Count },
+            { "color", GetColorForStatus(item.Status) }
         }).ToList<object>();
 
         chartReady = true;
@@ -94,7 +101,7 @@
         {
             if (chartReady && isClientReady)
                 await Task.Delay(1000);
-            await JS.InvokeVoidAsync("renderSpentChart", ChartData, TotalSpent);
+            await JS.InvokeVoidAsync("renderSpentChart", ChartData, TotalInProgress);
         }
         catch (JSException ex)
         {
@@ -104,10 +111,11 @@
 
     private async Task AddNewTask()
     {
-        BudgetItems.Add(new BudgetItemDto
+        StatusItems.Add(new StatusItemDto
         {
-            CategoryName = $"Task {nextTaskId++}",
-            ActualAmount = 0
+            Status = StatusType.InProgress,
+            StatusName = GetEnumDisplayName(StatusType.InProgress),
+            Count = 1
         });
 
         await RefreshChartAsync();
@@ -119,11 +127,24 @@
         await RenderChartAsync();
     }
 
-    private string GetColorForCategory(string? name) => name switch
+    private string GetColorForStatus(StatusType status) => status switch
     {
-        "Invitations & Stationary" => "#81B29A",
-        "Decor & Design" => "#E07A5F",
-        "Food & Beverage" => "#F2CC8F",
-        _ => "#CCCCCC"
+        StatusType.InProgress => "#007bff",
+        StatusType.Pending => "#dc3434",
+        StatusType.WaitingForReview => "#7ec2f3",
+        StatusType.Tabled => "#ff1493",
+        StatusType.TemporaryTabled => "#d2b045",
+        StatusType.Done => "#28a745",
+        _ => "#206d62"
     };
+
+    private static string GetEnumDisplayName(StatusType status)
+    {
+        var displayAttribute = status.GetType()
+            .GetField(status.ToString())?
+            .GetCustomAttributes(typeof(DisplayAttribute), false)
+            .FirstOrDefault() as DisplayAttribute;
+
+        return displayAttribute?.Name ?? status.ToString();
+    }
 }

--- a/CamcoTasks/wwwroot/js/Chart.js
+++ b/CamcoTasks/wwwroot/js/Chart.js
@@ -9,26 +9,18 @@
 
     const myChart = echarts.init(chartDom);
 
-    const categoryIcons = {
-        "Invitations & Stationary": 'circle',
-        "Decor & Design": 'rect',
-        "Food & Beverage": 'triangle'
-    };
-
-    // Ensure correct casing for JS property access
     const data = (budgetItems || []).map(item => ({
         value: item.actualAmount ?? item.ActualAmount,
         name: item.categoryName ?? item.CategoryName,
-        itemStyle: { color: item.color ?? item.Color },
-        icon: categoryIcons[item.categoryName ?? item.CategoryName] || 'circle'
+        itemStyle: { color: item.color ?? item.Color }
     }));
 
     const hasData = data.length > 0;
 
     function getCenterText(amount) {
         return [
-            '{spent|SPENT}',
-            `$${amount.toLocaleString(undefined, {
+            '{spent|TASKS IN PROGRESS}',
+            `${amount.toLocaleString(undefined, {
                 minimumFractionDigits: 0,
                 maximumFractionDigits: 0
             })}`
@@ -38,7 +30,7 @@
     const textPos = { left: 'center', top: 'center' };
     const seriesPos = {
         center: ['50%', '50%'],
-        radius: hasData ? ['30%', '60%'] : ['40%', '70%']
+        radius: hasData ? ['40%', '75%'] : ['50%', '80%']
     };
 
     const options = {
@@ -56,7 +48,7 @@
                         ${params.name}
                     </div>
                     <div style="text-align:left;font-size:12px;line-height:16px;">
-                        $${params.value}
+                        ${params.value}
                     </div>`;
             }
         },
@@ -83,10 +75,7 @@
                 }
             },
             formatter: name => `{text|${name}}`,
-            data: data.map(item => ({
-                name: item.name,
-                icon: item.icon
-            }))
+            data: data.map(item => item.name)
         },
         graphic: {
             elements: [
@@ -159,15 +148,7 @@
     const debouncedResize = debounce(() => myChart.resize(), 200);
     window.addEventListener('resize', debouncedResize);
 
-    myChart.on('legendselectchanged', function (event) {
-        let selected = event.selected;
-        let newTotal = 0;
-        data.forEach(item => {
-            if (selected[item.name] !== false) {
-                newTotal += item.value;
-            }
-        });
-
+    myChart.on('legendselectchanged', function () {
         myChart.setOption({
             graphic: {
                 elements: [
@@ -176,7 +157,7 @@
                         left: textPos.left,
                         top: textPos.top,
                         style: {
-                            text: getCenterText(newTotal),
+                            text: getCenterText(totalSpent),
                             textAlign: 'center',
                             textVerticalAlign: 'middle',
                             fontSize: 24,


### PR DESCRIPTION
## Summary
- adjust chart height for visibility
- group tasks by status id to accurately count In Progress tasks
- simplify chart JS and remove unused icons
- ensure legend uses status names only

## Testing
- `dotnet --version` *(fails: command not found)*
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_688cbd4d7770832db1f26f93b6756802