### PR TITLE
Fix TaskChart asset paths and reconnect handler

### DIFF
--- a/CamcoTasks/Pages/Chart.razor
+++ b/CamcoTasks/Pages/Chart.razor
@@ -15,7 +15,7 @@
             <div class="text-[#171412] text-base font-medium leading-6 font-['Roboto']">
                 Task Statuses
             </div>
-            <img class="img" src="img/budget-menu-icon.svg" />
+            <img class="img" src="/img/budget-menu-icon.svg" />
         </div>
         <button class="btn btn-primary btn-sm" @onclick="AddNewTask">ADD NEW TASK</button>
     </div>
@@ -129,21 +129,14 @@
 
     private string GetColorForStatus(StatusType status) => status switch
     {
-        StatusType.InProgress => "#81B29A",
-        StatusType.Pending => "#E07A5F",
-        StatusType.WaitingForReview => "#F2CC8F",
-        StatusType.Tabled => "#6D597A",
-        StatusType.TemporaryTabled => "#B56576",
-        StatusType.Done => "#355070",
-        StatusType.Default => "#CCCCCC",
-        _ => "#CCCCCC"
         StatusType.InProgress => "#007bff",
         StatusType.Pending => "#dc3434",
         StatusType.WaitingForReview => "#7ec2f3",
         StatusType.Tabled => "#ff1493",
         StatusType.TemporaryTabled => "#d2b045",
         StatusType.Done => "#28a745",
-        _ => "#206d62"
+        StatusType.Default => "#CCCCCC",
+        _ => "#206d62",
     };
 
     private static string GetEnumDisplayName(StatusType status)

--- a/CamcoTasks/Pages/_Layout.cshtml
+++ b/CamcoTasks/Pages/_Layout.cshtml
@@ -18,7 +18,7 @@
     <link href="CamcoTasks.styles.css" rel="stylesheet" />
 
     <!-- Third-party -->
-    <link href="_content/Blazored.Toast/blazored-toast.min.css" rel="stylesheet" />
+    <link href="/_content/Blazored.Toast/blazored-toast.min.css" rel="stylesheet" />
     <link href="_content/Syncfusion.Blazor.Themes/fabric.css" rel="stylesheet" />
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
     <link rel="stylesheet" href="fontawesome-free-6.4.2-web/css/all.min.css" />
@@ -65,8 +65,10 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/echarts/5.6.0/echarts.min.js" integrity="sha512-XSmbX3mhrD2ix5fXPTRQb2FwK22sRMVQTpBP2ac8hX7Dh/605hA2QDegVWiAvZPiXIxOV0CbkmUjGionDpbCmw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="~/js/Chart.js"></script>
     <script>
-        Blazor.defaultReconnectionHandler._reconnectCallback = function (d) {
-            document.location.reload();
+        if (window.Blazor && Blazor.defaultReconnectionHandler) {
+            Blazor.defaultReconnectionHandler._reconnectCallback = function () {
+                document.location.reload();
+            };
         }
     </script>
 </body>

--- a/CamcoTasks/wwwroot/img/budget-menu-icon.svg
+++ b/CamcoTasks/wwwroot/img/budget-menu-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <rect x="3" y="6" width="18" height="2" fill="#000000"/>
+  <rect x="3" y="11" width="18" height="2" fill="#000000"/>
+  <rect x="3" y="16" width="18" height="2" fill="#000000"/>
+</svg>

--- a/CamcoTasks/wwwroot/js/CustomJs.js
+++ b/CamcoTasks/wwwroot/js/CustomJs.js
@@ -133,7 +133,7 @@ function StartprintDiv(DivId) {
     mywindow.document.write('<link rel="stylesheet" href="/css/bootstrap/bootstrap.min.css" />');
     mywindow.document.write('<link href="_content/Syncfusion.Blazor/styles/fabric.css" rel="stylesheet" />');
     mywindow.document.write('<link href="_content/Syncfusion.Blazor/styles/bootstrap4.css" rel="stylesheet" />');
-    mywindow.document.write('<link href="_content/Blazored.Toast/blazored-toast.min.css" rel="stylesheet" />');
+    mywindow.document.write('<link href="/_content/Blazored.Toast/blazored-toast.min.css" rel="stylesheet" />');
 
     mywindow.document.write('</head><body >');
     mywindow.document.write('<h1>' + document.title + '</h1>');


### PR DESCRIPTION
## Summary
- fix missing budget menu icon and use root-relative path
- simplify GetColorForStatus switch for task chart
- guard Blazor reconnect handler and correct Blazored Toast paths

## Testing
- `dotnet build CamcoTasks.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890971b5a28832daa1a393a62b561d0