### PR TITLE
Ensure chart renders after data load

### DIFF
--- a/CamcoTasks/Pages/Chart.razor
+++ b/CamcoTasks/Pages/Chart.razor
@@ -49,6 +49,7 @@
     private List<ChartItem> ChartData { get; set; } = new();
     private bool chartReady = false;
     private bool isClientReady = false;
+    private bool chartRendered = false;
     private int TotalInProgress { get; set; } = 0;
     private bool _hasInitialized;
 
@@ -64,7 +65,12 @@
         if (firstRender)
         {
             isClientReady = true;
+        }
+
+        if (chartReady && isClientReady && !chartRendered)
+        {
             await RenderChartAsync();
+            chartRendered = true;
         }
     }
 
@@ -125,8 +131,9 @@
 
     private async Task RefreshChartAsync()
     {
+        chartRendered = false;
         await LoadChartDataAsync();
-        await RenderChartAsync();
+        // Rendering will occur in OnAfterRenderAsync
     }
 
     private string GetColorForStatus(StatusType status) => status switch

--- a/CamcoTasks/Pages/_Layout.cshtml
+++ b/CamcoTasks/Pages/_Layout.cshtml
@@ -66,9 +66,10 @@
     <script src="~/js/Chart.js"></script>
     <script>
         if (window.Blazor && Blazor.defaultReconnectionHandler) {
-              Blazor.defaultReconnectionHandler._reconnectCallback = function () {
-                  document.location.reload();
-              };
+            Blazor.defaultReconnectionHandler._reconnectCallback = function () {
+                document.location.reload();
+            };
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Render chart only after both data and client are ready
- Reset chart state when refreshing data
- Fix missing brace in layout reconnect script

## Testing
- `dotnet build CamcoTasks.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68909eda0674832daccb76c48ad88131