### PR TITLE
Fix chart data property casing for status chart

### DIFF
--- a/CamcoTasks/wwwroot/js/Chart.js
+++ b/CamcoTasks/wwwroot/js/Chart.js
@@ -15,12 +15,12 @@
         "Food & Beverage": 'triangle'
     };
 
-    // Ensure correct casing for JS property access
+    // Ensure correct casing for JS property access (camelCase from C# objects)
     const data = (budgetItems || []).map(item => ({
-        value: item.ActualAmount,
-        name: item.CategoryName,
-        color: item.Color, // ✅ Directly assign color for pie slice
-        icon: categoryIcons[item.CategoryName] || 'circle'
+        value: item.actualAmount,
+        name: item.categoryName,
+        color: item.color, // ✅ Directly assign color for pie slice
+        icon: categoryIcons[item.categoryName] || 'circle'
     }));
     const hasData = data.length > 0;
 


### PR DESCRIPTION
## Summary
- Correct JS property casing in custom chart rendering so pie chart segments display

## Testing
- `dotnet build CamcoTasks.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890a0cd50a8832db3d2523bc0f8881a