### PR TITLE
Show all task statuses on status chart

### DIFF
--- a/CamcoTasks/Pages/Chart.razor
+++ b/CamcoTasks/Pages/Chart.razor
@@ -78,13 +78,16 @@
     {
         var tasks = (await TasksService.GetAllTasks()).ToList();
 
-        StatusItems = tasks
+        var taskGroups = tasks
             .GroupBy(t => t.TaskStatusId.HasValue ? (StatusType)t.TaskStatusId.Value : StatusType.Default)
-            .Select(g => new StatusItemDto
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        StatusItems = Enum.GetValues<StatusType>()
+            .Select(status => new StatusItemDto
             {
-                Status = g.Key,
-                StatusName = GetEnumDisplayName(g.Key),
-                Count = g.Count()
+                Status = status,
+                StatusName = GetEnumDisplayName(status),
+                Count = taskGroups.TryGetValue(status, out var count) ? count : 0
             })
             .ToList();
 

--- a/CamcoTasks/wwwroot/js/Chart.js
+++ b/CamcoTasks/wwwroot/js/Chart.js
@@ -15,12 +15,12 @@
         "Food & Beverage": 'triangle'
     };
 
-    // Ensure correct casing for JS property access
+    // Ensure correct casing for JS property access (camelCase from C# objects)
     const data = (budgetItems || []).map(item => ({
-        value: item.ActualAmount,
-        name: item.CategoryName,
-        color: item.Color, // ✅ Directly assign color for pie slice
-        icon: categoryIcons[item.CategoryName] || 'circle'
+        value: item.actualAmount,
+        name: item.categoryName,
+        itemStyle: { color: item.color }, // ✅ Ensure slice color matches status
+        icon: categoryIcons[item.categoryName] || 'circle'
     }));
     const hasData = data.length > 0;
 


### PR DESCRIPTION
## Summary
- Include every status type in chart data so empty statuses still appear
- Render each pie slice using the status color for matching legend markers

## Testing
- `dotnet build CamcoTasks.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden – repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890a0cd50a8832db3d2523bc0f8881a