### PR TITLE
Ensure task chart updates when tasks change

### DIFF
--- a/CamcoTasks/Pages/Chart.razor
+++ b/CamcoTasks/Pages/Chart.razor
@@ -2,8 +2,11 @@
 @using CamcoTasks.Infrastructure.EnumHelper.Enums.Task
 @using System.ComponentModel.DataAnnotations
 @using CamcoTasks.Service.IService
+@using CamcoTasks.Services
 @inject ITasksService TasksService
 @inject IJSRuntime JS
+@inject TaskStateService TaskStateService
+@implements IDisposable
 
 <div class="inline-flex items-center gap-4 p-4 w-full h-full rounded-[16px] flex-col overflow-visible"
      style="background: white; outline: 1px #ECEBE9 solid; outline-offset: -1px;">
@@ -43,6 +46,7 @@
     {
         if (_hasInitialized) return;
         _hasInitialized = true;
+        TaskStateService.OnChange += HandleTaskStateChange;
         await LoadChartDataAsync();
     }
 
@@ -121,7 +125,18 @@
     {
         chartRendered = false;
         await LoadChartDataAsync();
+        await InvokeAsync(StateHasChanged);
         // Rendering will occur in OnAfterRenderAsync
+    }
+
+    private void HandleTaskStateChange()
+    {
+        _ = InvokeAsync(async () => await RefreshChartAsync());
+    }
+
+    public void Dispose()
+    {
+        TaskStateService.OnChange -= HandleTaskStateChange;
     }
 
     private string GetColorForStatus(StatusType status) => status switch

--- a/CamcoTasks/Pages/Tasks/ViewTasks/TasksCreateComponent.razor.cs
+++ b/CamcoTasks/Pages/Tasks/ViewTasks/TasksCreateComponent.razor.cs
@@ -20,6 +20,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Net;
 using static CamcoTasks.Pages.Tasks.ViewOneTimeSubTasks;
 using FileInfo = Syncfusion.Blazor.Inputs.FileInfo;
+using CamcoTasks.Services;
 
 namespace CamcoTasks.Pages.Tasks.ViewTasks
 {
@@ -44,6 +45,7 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
         [Inject] ICommonDataService ICommonDataService { get; set; }
         [Inject] ICamcoProjectService CamcoProjectService { get; set; }
         [Inject] IUserContextService UserContextService { get; set; }
+        [Inject] private TaskStateService TaskStateService { get; set; }
         [Parameter]
         public TasksTasksViewModel OneTimeTask { get; set; }
         [Parameter]
@@ -418,6 +420,7 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
 
                     }
                     await ReloadParentComponent.InvokeAsync(true);
+                    TaskStateService.NotifyStateChanged();
 
                 }
             }
@@ -513,6 +516,7 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
                 //await taskLogsService.SaveChangeLogAsync(logEntry);
 
                 await ReloadParentComponent.InvokeAsync(true);
+                TaskStateService.NotifyStateChanged();
 
             }
 

--- a/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor.cs
+++ b/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor.cs
@@ -26,6 +26,7 @@ using CamcoTasks.Service.Service;
 using System.Threading.Tasks;
 using CamcoTasks.Infrastructure.EnumHelper.Enums.Task;
 using CamcoTasks.Infrastructure.Defaults;
+using CamcoTasks.Services;
 
 
 
@@ -49,6 +50,7 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
         [Inject] protected IEmployeeService EmployeeService { get; set; }
         [Inject] protected IHttpContextAccessor HttpContextAccessor { get; set; }
         [Inject] protected IUserContextService UserContextService { get; set; }
+        [Inject] private TaskStateService TaskStateService { get; set; }
         public OnetimeTaskBorderModel BorderModel { get; set; } = new OnetimeTaskBorderModel();
         protected SfComboBox<string, EmployeeViewModel> SelectEmployeeDropDown { get; set; }
         protected string StatusDropdownVal { get; set; } = "2";
@@ -1059,6 +1061,7 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
                     await TaskGrid.Refresh();
                     _toastService.ShowSuccess("Task status updated successfully.");
                     statusModalDisplay = "none";
+                    TaskStateService.NotifyStateChanged();
                 }
                 else
                 {

--- a/CamcoTasks/Program.cs
+++ b/CamcoTasks/Program.cs
@@ -8,6 +8,7 @@ using CamcoTasks.Infrastructure.Entities;
 using CamcoTasks.Infrastructure.Entities.Login;
 using CamcoTasks.Service.IService;
 using CamcoTasks.Service.Service;
+using CamcoTasks.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.EntityFrameworkCore;
@@ -67,6 +68,7 @@ builder.Services.AddSyncfusionBlazor();
 builder.Services.AddBlazoredToast();
 builder.Services.AddBlazorDownloadFile(ServiceLifetime.Scoped);
 builder.Services.AddScoped<IPrintingService, PrintingService>();
+builder.Services.AddScoped<TaskStateService>();
 
 
 builder.Services.AddLocalization(opts => opts.ResourcesPath = "Resources");

--- a/CamcoTasks/Services/TaskStateService.cs
+++ b/CamcoTasks/Services/TaskStateService.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace CamcoTasks.Services
+{
+    public class TaskStateService
+    {
+        public event Action? OnChange;
+
+        public void NotifyStateChanged()
+        {
+            OnChange?.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TaskStateService to broadcast task changes
- refresh chart when service signals updates
- notify chart on task create and status changes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890af64ffec832d9c81db1a6a69cc9b