### PR TITLE
Fix TaskStateService duplication and clean up state notifications

### DIFF
--- a/CamcoTasks/Pages/Tasks/ViewTasks/TasksCreateComponent.razor.cs
+++ b/CamcoTasks/Pages/Tasks/ViewTasks/TasksCreateComponent.razor.cs
@@ -420,8 +420,6 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
 
                     }
                     await ReloadParentComponent.InvokeAsync(true);
-                    await TaskStateService.NotifyStateChanged();
-                    TaskStateService.NotifyStateChanged();
                     await TaskStateService.NotifyStateChangedAsync();
 
                 }
@@ -517,8 +515,6 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
                 //Need to add service properly
 
                 await ReloadParentComponent.InvokeAsync(true);
-                await TaskStateService.NotifyStateChanged();
-                TaskStateService.NotifyStateChanged();
                 await TaskStateService.NotifyStateChangedAsync();
 
             }

--- a/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor.cs
+++ b/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor.cs
@@ -1061,12 +1061,7 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
                     await TaskGrid.Refresh();
                     _toastService.ShowSuccess("Task status updated successfully.");
                     statusModalDisplay = "none";
-<<<<<<< HEAD
-                    await TaskStateService.NotifyStateChanged();
-                    TaskStateService.NotifyStateChanged();
-=======
                     await TaskStateService.NotifyStateChangedAsync();
->>>>>>> parent of a1e04bf (Merge branch 'main' into lnohn4-codex/fix-chart-data-synchronization)
                 }
                 else
                 {

--- a/CamcoTasks/Services/TaskStateService.cs
+++ b/CamcoTasks/Services/TaskStateService.cs
@@ -5,24 +5,11 @@ namespace CamcoTasks.Services
 {
     public class TaskStateService
     {
-<<<<<<< HEAD
-        public event Func<Task>? OnChange;
-
-        public Task NotifyStateChanged()
-        {
-            return OnChange?.Invoke() ?? Task.CompletedTask;
-        public event Action? OnChange;
-
-        public void NotifyStateChanged()
-        {
-            OnChange?.Invoke();
-=======
         public event Func<Task>? StateChanged;
 
         public Task NotifyStateChangedAsync()
         {
             return StateChanged?.Invoke() ?? Task.CompletedTask;
->>>>>>> parent of a1e04bf (Merge branch 'main' into lnohn4-codex/fix-chart-data-synchronization)
         }
     }
 }


### PR DESCRIPTION
## Summary
- resolve merge conflicts in `TaskStateService` and restore async state change API
- use single asynchronous state change notification in task components

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Unable to locate package dotnet-sdk-6.0)*

------
https://chatgpt.com/codex/tasks/task_e_6890bc414124832dab9fe29e2d8e7a0d