### PR TITLE
fix: show filter modal

### DIFF
--- a/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor
+++ b/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor
@@ -191,8 +191,8 @@ else
                                 <ToolbarItem Type="ItemType.Input">
                                     <Template>
                                         @{
-                                            <a href="" class="custom-filter-button btn btn-light d-flex align-items-center px-3 py-2 m-0 font-weight-bold"
-                                               role="button" data-toggle="modal" data-target="#filterModal" data-placement="top" data-original-title="Filter">
+                                            <a href="javascript:void(0);" class="custom-filter-button btn btn-light d-flex align-items-center px-3 py-2 m-0 font-weight-bold"
+                                               role="button" data-bs-toggle="modal" data-bs-target="#filterModal" data-placement="top" data-original-title="Filter">
                                                 <i class="e-icons e-filter mr-2"></i>
                                                 <span class="filter-text">Filter</span>
                                                 <span class="ml-auto"><i class="e-icons e-chevron-down"></i></span>
@@ -919,8 +919,8 @@ else
                             <ToolbarItem Type="ItemType.Input">
                                 <Template>
                                     @{
-                                        <a href="" class="custom-filter-button btn btn-light d-flex align-items-center px-3 py-2 m-0 font-weight-bold"
-                                           role="button" data-toggle="modal" data-target="#filterModal" data-placement="top" data-original-title="Filter">
+                                        <a href="javascript:void(0);" class="custom-filter-button btn btn-light d-flex align-items-center px-3 py-2 m-0 font-weight-bold"
+                                           role="button" data-bs-toggle="modal" data-bs-target="#filterModal" data-placement="top" data-original-title="Filter">
                                             <i class="e-icons e-filter mr-2"></i>
                                             <span class="filter-text">Filter</span>
                                             <span class="ml-auto"><i class="e-icons e-chevron-down"></i></span>


### PR DESCRIPTION
## Summary
- fix filter button markup so modal displays

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890cfb9bc10832db5b00eade11cc960