### PR TITLE
Show only logged-in user's tasks

### DIFF
--- a/CamcoTasks.Service/IService/ITasksService.cs
+++ b/CamcoTasks.Service/IService/ITasksService.cs
@@ -35,6 +35,8 @@ namespace CamcoTasks.Service.IService
         Task<IEnumerable<TasksTasksViewModel>> GetAllTasks2();
         Task<IEnumerable<TasksTasksViewModel>> GetAllTasks3(string taskId);
 
+        Task<IEnumerable<TasksTasksViewModel>> GetTasksByPerson(string personResponsible);
+
         Task<IEnumerable<TasksTasksViewModel>> GetAllTasks(string OldTypeValue);
 
         Task<IEnumerable<TasksTasksViewModel>> GetAllTasksSync();

--- a/CamcoTasks.Service/Service/TasksService.cs
+++ b/CamcoTasks.Service/Service/TasksService.cs
@@ -248,16 +248,31 @@ namespace CamcoTasks.Service.Service
 				x.ParentTaskId == null));
 		}
 
-		public async Task<IEnumerable<TasksTasksViewModel>> GetAllTasks3(string TaskId)
-		{
-			return TasksTasksDTONew.Map(await _unitOfWork.TaskTasks.FindAllAsync(x => (x.IsDeleted == false) &&
-				x.ParentTaskId == Convert.ToInt32(TaskId)));
-		}
+                public async Task<IEnumerable<TasksTasksViewModel>> GetAllTasks3(string TaskId)
+                {
+                        return TasksTasksDTONew.Map(await _unitOfWork.TaskTasks.FindAllAsync(x => (x.IsDeleted == false) &&
+                                x.ParentTaskId == Convert.ToInt32(TaskId)));
+                }
 
-		public async Task<IEnumerable<TasksTasksViewModel>> GetAllTasks(string OldTypeValue)
-		{
-			return TasksTasksDTONew.Map(await _unitOfWork.TaskTasks.FindAllAsync(x => x.TaskType == OldTypeValue));
-		}
+                public async Task<IEnumerable<TasksTasksViewModel>> GetTasksByPerson(string personFullName)
+                {
+                        if (string.IsNullOrWhiteSpace(personFullName))
+                        {
+                                return Enumerable.Empty<TasksTasksViewModel>();
+                        }
+
+                        var normalized = personFullName.Trim().ToLower();
+
+                        return TasksTasksDTONew.Map(await _unitOfWork.TaskTasks.FindAllAsync(x => (x.IsDeleted == null || x.IsDeleted == false)
+                                                                                                     && x.ParentTaskId == null
+                                                                                                     && x.PersonResponsible != null
+                                                                                                     && x.PersonResponsible.ToLower() == normalized));
+                }
+
+                public async Task<IEnumerable<TasksTasksViewModel>> GetAllTasks(string OldTypeValue)
+                {
+                        return TasksTasksDTONew.Map(await _unitOfWork.TaskTasks.FindAllAsync(x => x.TaskType == OldTypeValue));
+                }
 
 		public async Task<IEnumerable<TasksTasksViewModel>> GetAllTasksSync()
 		{

--- a/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor.cs
+++ b/CamcoTasks/Pages/Tasks/ViewTasks/TasksViewTasks.razor.cs
@@ -316,9 +316,30 @@ namespace CamcoTasks.Pages.Tasks.ViewTasks
 
         protected async Task LoadData()
         {
-            mainTasksModel = (await taskService.GetAllTasks()).OrderByDescending(x => x.Id).ToList();
             employeeList = await EmployeeService.GetListAsync(true, false);
             Employees = employeeList.Where(a => a.FullName != null).ToList();
+
+            if (UserContextService.CurrentEmployeeId != 0)
+            {
+                var currentEmployee = employeeList.FirstOrDefault(a => a.Id == UserContextService.CurrentEmployeeId);
+                if (currentEmployee != null)
+                {
+                    var personName = currentEmployee.FullName?.Trim();
+                    var tasksByPerson = await taskService.GetTasksByPerson(personName);
+                    mainTasksModel = tasksByPerson
+                        .OrderByDescending(x => x.Id)
+                        .ToList();
+                }
+                else
+                {
+                    mainTasksModel = new();
+                }
+            }
+            else
+            {
+                mainTasksModel = new();
+            }
+
             await AssignLatestUpdates();
             Tasks = mainTasksModel.Where(a => !a.DateCompleted.HasValue).ToList();
             TaskTypes = mainTasksModel.Where(a => !a.DateCompleted.HasValue && !string.IsNullOrWhiteSpace(a.TaskType))


### PR DESCRIPTION
## Summary
- add `GetTasksByPerson` service method to fetch tasks assigned to a specific user
- filter task list page by the current user's ID
- remove unused MVC controller and related routing
- avoid showing all tasks when no employee record exists for the logged-in user
- normalize name comparison when fetching user tasks so matching is case-insensitive
- convert the fetched user tasks to a list before assigning to the main task list to fix a build error

## Testing
- `dotnet build CamcoTasks.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.147 8080])*

------
https://chatgpt.com/codex/tasks/task_e_6892371643d8832da9f37e7474a26b4b